### PR TITLE
Implement Items Counter Functionality

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import fetchBooks from './modules/api.js';
 import displayBooks from './modules/books.js';
+import itemsCounter from './modules/counter.js';
 import './style.css';
 import 'font-awesome/css/font-awesome.min.css';
 
@@ -10,4 +11,9 @@ logo.src = Logo;
 
 fetchBooks().then((data) => {
   displayBooks(data);
+  // Get the count of items
+  const count = itemsCounter(data);
+
+  // Update the DOM with the count
+  document.getElementById('itemsCounter').textContent = `Items(${count})`;
 });

--- a/src/modules/counter.js
+++ b/src/modules/counter.js
@@ -1,0 +1,3 @@
+const itemsCounter = (items) => items.length;
+
+export default itemsCounter;

--- a/src/style.css
+++ b/src/style.css
@@ -83,6 +83,7 @@ li:hover {
   height: 250px;
   object-fit: cover;
   border-bottom: 1px solid #333;
+  margin-bottom: -1vh;
 }
 
 footer p {

--- a/src/template.html
+++ b/src/template.html
@@ -24,7 +24,7 @@
     </nav>
   </header>
   <footer>
-    <p>&copy; 2023 BookReviews. All rights reserved.</p>
+    <p>&copy; Created by Cristian Villa, Gumaro Monroy & Pablo Thasi under CC license. 2023</p>
   </footer>
 </body>
 


### PR DESCRIPTION
# Description

In this pull request, I've introduced the functionality to display the number of items (books) on the homepage.

**Key features:**
- New module `counter.js` exporting the `itemsCounter` function.
- Integration of `itemsCounter` in `index.js` to update the counter after fetching items.
- Dynamic update of `Items()` counter in the header navigation.

Please review and provide feedback.
